### PR TITLE
Add GitHub Pages Deployment as a Subtree  

### DIFF
--- a/Projects/github-pages-deployment/.github/workflows/static.yml
+++ b/Projects/github-pages-deployment/.github/workflows/static.yml
@@ -1,0 +1,43 @@
+# Simple workflow for deploying static content to GitHub Pages
+name: Deploy static content to Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Single deploy job since we're just deploying
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          # Upload entire repository
+          path: '.'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/Projects/github-pages-deployment/README.md
+++ b/Projects/github-pages-deployment/README.md
@@ -1,0 +1,22 @@
+# GitHub Pages Deployment
+
+## 🚀 Project Overview
+This project demonstrates how to use **GitHub Actions** to implement **Continuous Integration (CI) and Continuous Deployment (CD)** for a static website hosted on **GitHub Pages**. The workflow ensures that changes made to the `index.html` file in the main branch are automatically deployed.
+
+## 🛠 Requirements
+- A **GitHub repository** (e.g., `gh-deployment-workflow`).
+- A simple `index.html` file containing: `"Hello, GitHub Actions!"`.
+- A **GitHub Actions workflow** in `.github/workflows/deploy.yml` to handle deployment.
+- The workflow should only trigger when `index.html` is modified.
+- The website should be accessible at: `https://<username>.github.io/gh-deployment-workflow/`.
+
+## 🎯 Stretch Goals
+- Use a static site generator like **Hugo, Jekyll, or Astro** to create a more advanced site (e.g., a portfolio).
+
+## 📚 Key Concepts Learned
+- **GitHub Actions**
+- **GitHub Pages Deployment**
+- **CI/CD Pipelines**
+- **Writing GitHub Actions Workflows**
+
+For more details, check out: [GitHub Actions Deployment Workflow Project](https://roadmap.sh/projects/github-actions-deployment-workflow)

--- a/Projects/github-pages-deployment/index.html
+++ b/Projects/github-pages-deployment/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>GitHub Actions Deployment</title>
+</head>
+<body>
+    <h1>Hello, GitHub Actions!</h1>
+</body>
+</html>


### PR DESCRIPTION
#### **Description:**  
This PR adds the **GitHub Pages Deployment** repository as a **subtree** inside the folder `Projects/github-pages-deployment`. The subtree allows for seamless synchronization of the deployment workflow while keeping it modular.  

#### **Changes:**  
- Added `gh-deployment-workflow` as a subtree in `Projects/github-pages-deployment`.  
- Included the latest commits from the `main` branch of `gh-deployment-workflow`.  

#### **How to Pull Future Updates:**  
To fetch the latest changes from `gh-deployment-workflow`:  
```sh
git subtree pull --prefix=Projects/github-pages-deployment https://github.com/ZakariaAitAli/gh-deployment-workflow.git main --squash
```

#### **How to Push Updates Back:**  
If changes are made inside `Projects/github-pages-deployment` and need to be pushed back:  
```sh
git subtree push --prefix=Projects/github-pages-deployment https://github.com/ZakariaAitAli/gh-deployment-workflow.git main
```

#### **Why Use Git Subtree?**  
- Keeps the project structure clean.  
- Allows independent development of the deployment workflow.  
- Enables synchronization without dealing with Git submodules.  

#### **Review & Merge Request:**  
- [ ] Verify folder structure.  
- [ ] Ensure subtree syncs correctly.  
- [ ] Merge once validated.  

🚀 **Let me know if any modifications are needed!**